### PR TITLE
Hotkeys

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -148,8 +148,20 @@ function App({
             }
           });
 
+          editor.addShortcut("meta+shift+L", "Align left", function () {
+            editor.execCommand("JustifyLeft");
+          });
+
+          editor.addShortcut("meta+shift+R", "Align right", function () {
+            editor.execCommand("JustifyRight");
+          });
+
+          editor.addShortcut("meta+shift+E", "Align center", function () {
+            editor.execCommand("JustifyCenter");
+          });
+
           editor.on("keydown", (event) => {
-            // doesnt work with add shortcut api
+            // Does not work with add shortcut api
             if (event.metaKey && event.key === "\\") {
               event.preventDefault();
               editor.execCommand("RemoveFormat");

--- a/src/App.js
+++ b/src/App.js
@@ -133,19 +133,17 @@ function App({
           editor.addShortcut("meta+shift+7", "Numbered List", function () {
             const selection = editor.dom.getParents(editor.selection.getNode());
             const isNumberedList = selection.some((node) => node === "ol");
-            if (isNumberedList) {
-              editor.execCommand("RemoveList");
-            } else {
+            editor.execCommand("RemoveList");
+            if (!isNumberedList) {
               editor.execCommand("InsertOrderedList");
             }
           });
 
           editor.addShortcut("meta+shift+8", "Bulleted List", function () {
             const selection = editor.dom.getParents(editor.selection.getNode());
-            const isNumberedList = selection.some((node) => node === "ul");
-            if (isNumberedList) {
-              editor.execCommand("RemoveList");
-            } else {
+            const isBulletedList = selection.some((node) => node === "ul");
+            editor.execCommand("RemoveList");
+            if (!isBulletedList) {
               editor.execCommand("InsertUnorderedList");
             }
           });

--- a/src/App.js
+++ b/src/App.js
@@ -129,7 +129,6 @@ function App({
           });
 
           editor.addShortcut("meta+shift+7", "Numbered List", function () {
-            console.log("numbered list");
             const selection = editor.dom.getParents(editor.selection.getNode());
             const isNumberedList = selection.some((node) => node === "li");
             if (isNumberedList) {
@@ -140,7 +139,13 @@ function App({
           });
 
           editor.addShortcut("meta+shift+8", "Bulleted List", function () {
-            console.log("bulleted list");
+            const selection = editor.dom.getParents(editor.selection.getNode());
+            const isNumberedList = selection.some((node) => node === "ol");
+            if (isNumberedList) {
+              editor.execCommand("RemoveList");
+            } else {
+              editor.execCommand("InsertUnorderedList");
+            }
           });
 
           editor.on("keydown", (event) => {
@@ -151,7 +156,7 @@ function App({
             } else if (event.metaKey && event.key === "[") {
               event.preventDefault();
               editor.execCommand("Outdent");
-            } else if (event.metaKey && event.key === "9") {
+            } else if (event.metaKey && event.key === "]") {
               event.preventDefault();
               editor.execCommand("Indent");
             }

--- a/src/App.js
+++ b/src/App.js
@@ -118,13 +118,18 @@ function App({
             scope: "node",
             position: "node",
           });
+
+          // Keyboard shortcuts
+          editor.addShortcut("meta+shift+X", "Strikethrough", function () {
+            editor.execCommand("Strikethrough");
+          });
         },
 
         branding: false,
         contextmenu: false,
         custom_ui_selector: ".custom-inline-strong",
         elementpath: false,
-        // TODO: temp fix 
+        // TODO: temp fix
         height: 5000,
 
         icons: "",

--- a/src/App.js
+++ b/src/App.js
@@ -165,24 +165,24 @@ function App({
             if (event.metaKey && event.key === "\\") {
               event.preventDefault();
               editor.execCommand("RemoveFormat");
-            } else if (event.metaKey && event.key === "[") {
+            }
+
+            if (event.metaKey && event.key === "[") {
               event.preventDefault();
               editor.execCommand("Outdent");
-            } else if (event.metaKey && event.key === "]") {
+            }
+
+            if (event.metaKey && event.key === "]") {
               event.preventDefault();
               editor.execCommand("Indent");
-            } else if (
-              event.metaKey &&
-              event.shiftKey &&
-              event.keyCode === 187
-            ) {
+            }
+
+            if (event.metaKey && event.shiftKey && event.keyCode === 187) {
               event.preventDefault();
               console.log("increase font size");
-            } else if (
-              event.metaKey &&
-              event.shiftKey &&
-              event.keyCode === 189
-            ) {
+            }
+
+            if (event.metaKey && event.shiftKey && event.keyCode === 189) {
               event.preventDefault();
               console.log("decrease font size");
             }

--- a/src/App.js
+++ b/src/App.js
@@ -130,6 +130,13 @@ function App({
 
           editor.addShortcut("meta+shift+7", "Numbered List", function () {
             console.log("numbered list");
+            const selection = editor.dom.getParents(editor.selection.getNode());
+            const isNumberedList = selection.some((node) => node === "li");
+            if (isNumberedList) {
+              editor.execCommand("RemoveList");
+            } else {
+              editor.execCommand("InsertOrderedList");
+            }
           });
 
           editor.addShortcut("meta+shift+8", "Bulleted List", function () {

--- a/src/App.js
+++ b/src/App.js
@@ -17,7 +17,9 @@ import {
   BlueColorButton,
   HighlightButton,
   SmallSizeButton,
+  NormalSizeButton,
   LargeSizeButton,
+  HugeSizeButton,
   RemoveFormatButton,
   BulletListButton,
   OrderListButton,
@@ -147,20 +149,45 @@ function App({
               editor.execCommand("InsertUnorderedList");
             }
           });
-          
+
           editor.addShortcut("meta+220", "Remove format", function () {
             editor.execCommand("RemoveFormat");
           });
+
+          const FONT_SIZES = ["10px", "13px", "18px", "32px"];
+          const FONT_SIZE_VALUE = {
+            "10px": "x-small",
+            "13px": "small",
+            "18px": "large",
+            "32px": "xx-large",
+          };
 
           editor.addShortcut(
             "meta+shift+187",
             "Increase Font Size",
             function () {
               const node = editor.selection.getNode();
-              const fontsize = editor.dom.getStyle(node, "font-size", true);
+              const currentFontSize = editor.dom.getStyle(
+                node,
+                "font-size",
+                true
+              );
 
-              console.log(fontsize);
-              editor.formatter.toggle("fontsize", { value: "large" });
+              if (currentFontSize === "32px") {
+                return;
+              }
+
+              const currFontSizeIndex = FONT_SIZES.indexOf(
+                currentFontSize ?? "13px"
+              );
+
+              const newFontSize = FONT_SIZES[currFontSizeIndex + 1];
+
+              editor.execCommand(
+                "FontSize",
+                false,
+                FONT_SIZE_VALUE[newFontSize]
+              );
             }
           );
 
@@ -169,10 +196,27 @@ function App({
             "Decrease Font Size",
             function () {
               const node = editor.selection.getNode();
-              const fontsize = editor.dom.getStyle(node, "font-size", true);
+              const currentFontSize = editor.dom.getStyle(
+                node,
+                "font-size",
+                true
+              );
 
-              console.log(fontsize);
-              editor.formatter.toggle("fontsize", { value: "x-small" });
+              if (currentFontSize === "10px") {
+                return;
+              }
+
+              const currFontSizeIndex = FONT_SIZES.indexOf(
+                currentFontSize ?? "13px"
+              );
+
+              const newFontSize = FONT_SIZES[currFontSizeIndex - 1];
+
+              editor.execCommand(
+                "FontSize",
+                false,
+                FONT_SIZE_VALUE[newFontSize]
+              );
             }
           );
 
@@ -206,7 +250,8 @@ function App({
 
         visual: false,
 
-        convert_fonts_to_spans: false,
+        convert_fonts_to_spans: true,
+        font_size_style_values: "x-small,small,large,xx-large",
         element_format: "html",
         forced_root_block: "div",
         //if set false the space key will not work
@@ -250,7 +295,9 @@ function App({
             <BlueColorButton />
             <HighlightButton />
             <SmallSizeButton />
+            <NormalSizeButton />
             <LargeSizeButton />
+            <HugeSizeButton />
             <RemoveFormatButton />
             <BulletListButton />
             <OrderListButton />

--- a/src/App.js
+++ b/src/App.js
@@ -248,8 +248,7 @@ function App({
 
         visual: false,
 
-        convert_fonts_to_spans: true,
-        font_size_style_values: "x-small,small,large,xx-large",
+        convert_fonts_to_spans: false,
         element_format: "html",
         forced_root_block: "div",
         //if set false the space key will not work

--- a/src/App.js
+++ b/src/App.js
@@ -171,6 +171,20 @@ function App({
             } else if (event.metaKey && event.key === "]") {
               event.preventDefault();
               editor.execCommand("Indent");
+            } else if (
+              event.metaKey &&
+              event.shiftKey &&
+              event.keyCode === 187
+            ) {
+              event.preventDefault();
+              console.log("increase font size");
+            } else if (
+              event.metaKey &&
+              event.shiftKey &&
+              event.keyCode === 189
+            ) {
+              event.preventDefault();
+              console.log("decrease font size");
             }
           });
         },

--- a/src/App.js
+++ b/src/App.js
@@ -217,7 +217,6 @@ function App({
         remove_trailing_brs: true,
         //the formats will change the format recognize
         formats: {
-          ordered_list: { selector: "ol, li" },
           //  bold: {inline: "b"},
           // italic: { inline: 'i' },
           // underline: { inline: 'u'},

--- a/src/App.js
+++ b/src/App.js
@@ -147,19 +147,7 @@ function App({
               editor.execCommand("InsertUnorderedList");
             }
           });
-
-          editor.addShortcut("meta+shift+L", "Align left", function () {
-            editor.execCommand("JustifyLeft");
-          });
-
-          editor.addShortcut("meta+shift+R", "Align right", function () {
-            editor.execCommand("JustifyRight");
-          });
-
-          editor.addShortcut("meta+shift+E", "Align center", function () {
-            editor.execCommand("JustifyCenter");
-          });
-
+          
           editor.addShortcut("meta+220", "Remove format", function () {
             editor.execCommand("RemoveFormat");
           });
@@ -168,6 +156,10 @@ function App({
             "meta+shift+187",
             "Increase Font Size",
             function () {
+              const node = editor.selection.getNode();
+              const fontsize = editor.dom.getStyle(node, "font-size", true);
+
+              console.log(fontsize);
               editor.formatter.toggle("fontsize", { value: "large" });
             }
           );
@@ -176,6 +168,10 @@ function App({
             "meta+shift+189",
             "Decrease Font Size",
             function () {
+              const node = editor.selection.getNode();
+              const fontsize = editor.dom.getStyle(node, "font-size", true);
+
+              console.log(fontsize);
               editor.formatter.toggle("fontsize", { value: "x-small" });
             }
           );

--- a/src/App.js
+++ b/src/App.js
@@ -179,12 +179,12 @@ function App({
 
             if (event.metaKey && event.shiftKey && event.keyCode === 187) {
               event.preventDefault();
-              console.log("increase font size");
+              editor.formatter.toggle("fontsize", { value: "large" });
             }
 
             if (event.metaKey && event.shiftKey && event.keyCode === 189) {
               event.preventDefault();
-              console.log("decrease font size");
+              editor.formatter.toggle("fontsize", { value: "x-small" });
             }
           });
         },

--- a/src/App.js
+++ b/src/App.js
@@ -128,14 +128,23 @@ function App({
             linkDialogRef.current.show();
           });
 
+          editor.addShortcut("meta+shift+7", "Numbered List", function () {
+            console.log("numbered list");
+          });
+
+          editor.addShortcut("meta+shift+8", "Bulleted List", function () {
+            console.log("bulleted list");
+          });
+
           editor.on("keydown", (event) => {
+            // doesnt work with add shortcut api
             if (event.metaKey && event.key === "\\") {
               event.preventDefault();
               editor.execCommand("RemoveFormat");
             } else if (event.metaKey && event.key === "[") {
               event.preventDefault();
               editor.execCommand("Outdent");
-            } else if (event.metaKey && event.key === "]") {
+            } else if (event.metaKey && event.key === "9") {
               event.preventDefault();
               editor.execCommand("Indent");
             }
@@ -170,6 +179,7 @@ function App({
         remove_trailing_brs: true,
         //the formats will change the format recognize
         formats: {
+          ordered_list: { selector: "ol, li" },
           //  bold: {inline: "b"},
           // italic: { inline: 'i' },
           // underline: { inline: 'u'},

--- a/src/App.js
+++ b/src/App.js
@@ -123,6 +123,10 @@ function App({
           editor.addShortcut("meta+shift+X", "Strikethrough", function () {
             editor.execCommand("Strikethrough");
           });
+
+          editor.addShortcut("meta+k", "Insert link", function () {
+            linkDialogRef.current.show();
+          });
         },
 
         branding: false,

--- a/src/App.js
+++ b/src/App.js
@@ -132,7 +132,7 @@ function App({
 
           editor.addShortcut("meta+shift+7", "Numbered List", function () {
             const selection = editor.dom.getParents(editor.selection.getNode());
-            const isNumberedList = selection.some((node) => node === "li");
+            const isNumberedList = selection.some((node) => node === "ol");
             if (isNumberedList) {
               editor.execCommand("RemoveList");
             } else {
@@ -142,7 +142,7 @@ function App({
 
           editor.addShortcut("meta+shift+8", "Bulleted List", function () {
             const selection = editor.dom.getParents(editor.selection.getNode());
-            const isNumberedList = selection.some((node) => node === "ol");
+            const isNumberedList = selection.some((node) => node === "ul");
             if (isNumberedList) {
               editor.execCommand("RemoveList");
             } else {

--- a/src/App.js
+++ b/src/App.js
@@ -160,32 +160,32 @@ function App({
             editor.execCommand("JustifyCenter");
           });
 
-          editor.on("keydown", (event) => {
-            // Does not work with add shortcut api
-            if (event.metaKey && event.key === "\\") {
-              event.preventDefault();
-              editor.execCommand("RemoveFormat");
-            }
+          editor.addShortcut("meta+220", "Remove format", function () {
+            editor.execCommand("RemoveFormat");
+          });
 
-            if (event.metaKey && event.key === "[") {
-              event.preventDefault();
-              editor.execCommand("Outdent");
-            }
-
-            if (event.metaKey && event.key === "]") {
-              event.preventDefault();
-              editor.execCommand("Indent");
-            }
-
-            if (event.metaKey && event.shiftKey && event.keyCode === 187) {
-              event.preventDefault();
+          editor.addShortcut(
+            "meta+shift+187",
+            "Increase Font Size",
+            function () {
               editor.formatter.toggle("fontsize", { value: "large" });
             }
+          );
 
-            if (event.metaKey && event.shiftKey && event.keyCode === 189) {
-              event.preventDefault();
+          editor.addShortcut(
+            "meta+shift+189",
+            "Decrease Font Size",
+            function () {
               editor.formatter.toggle("fontsize", { value: "x-small" });
             }
+          );
+
+          editor.addShortcut("meta+221", "Indent More", function () {
+            editor.execCommand("Indent");
+          });
+
+          editor.addShortcut("meta+219", "Indent Less", function () {
+            editor.execCommand("Outdent");
           });
         },
 

--- a/src/App.js
+++ b/src/App.js
@@ -127,6 +127,19 @@ function App({
           editor.addShortcut("meta+k", "Insert link", function () {
             linkDialogRef.current.show();
           });
+
+          editor.on("keydown", (event) => {
+            if (event.metaKey && event.key === "\\") {
+              event.preventDefault();
+              editor.execCommand("RemoveFormat");
+            } else if (event.metaKey && event.key === "[") {
+              event.preventDefault();
+              editor.execCommand("Outdent");
+            } else if (event.metaKey && event.key === "]") {
+              event.preventDefault();
+              editor.execCommand("Indent");
+            }
+          });
         },
 
         branding: false,

--- a/src/Buttons.js
+++ b/src/Buttons.js
@@ -83,7 +83,7 @@ export function BlueColorButton() {
 export function HighlightButton() {
   return (
     <MarkButton type="hilitecolor" value="#ffd41a">
-      Highlight color{" "}
+      Highlight color
     </MarkButton>
   );
 }

--- a/src/Buttons.js
+++ b/src/Buttons.js
@@ -88,10 +88,26 @@ export function HighlightButton() {
   );
 }
 
+export function HugeSizeButton() {
+  return (
+    <MarkButton type="fontsize" value="xx-large">
+      Huge size
+    </MarkButton>
+  );
+}
+
 export function LargeSizeButton() {
   return (
     <MarkButton type="fontsize" value="large">
       Large size
+    </MarkButton>
+  );
+}
+
+export function NormalSizeButton() {
+  return (
+    <MarkButton type="fontsize" value="small">
+      Normal size
     </MarkButton>
   );
 }


### PR DESCRIPTION
Currently supported hotkeys by TinyMCE

- [x]  Bold (`command+b`)
- [x]  Underline (`command+u`)
- [x]  Italicize (`command+i`)
- [x]  Undo (`command+z`)
- [x]  Redo (`command+y`)

Need to implement 

- [x]  Strike through (`command+shift+x`)
- [x]  Indent less (`command+[`)
- [x]  Indent more (`command+]`)
- [x]  Insert link (`command+k`)
- [x]  Numbered list (`command+shift+7`)
- [x]  Bulleted list (`command+shift+8`)
- [x]  Remove formatting (`command+\`)
- [x]  Font size (`command+shift+-`, `command+shift++`)
    - [x] 13px (small)
	- [x] 10px (x-small)
	- [x] 18px (large)
	- [x] 32px (Huge)

